### PR TITLE
Updates to states and modules for docker

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1302,9 +1302,11 @@ def images(verbose=False, **kwargs):
             if img_id is None:
                 continue
             for item in img:
-                img_state = 'untagged' \
-                    if img['RepoTags'] == ['<none>:<none>'] \
-                    else 'tagged'
+                img_state = ('untagged' if
+                             img['RepoTags'] in (
+                               ['<none>:<none>'],  # docker API <1.24
+                               None,  # docker API >=1.24
+                             ) else 'tagged')
                 bucket = __context__.setdefault('docker.images', {})
                 bucket = bucket.setdefault(img_state, {})
                 img_key = key_map.get(item, item)

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -50,7 +50,11 @@ def __virtual__():
     return (False, __salt__.missing_fun_string('docker.version'))
 
 
-def present(name, driver=None, containers=None):
+def present(name,
+            driver=None,
+            containers=None,
+            options=None,
+            ipam=None):
     '''
     Ensure that a network is present.
 
@@ -62,6 +66,12 @@ def present(name, driver=None, containers=None):
 
     containers:
         List of container names that should be part of this network
+
+    options
+        Network specific options to be used by the drivers
+
+    ipam
+        Optional custom IP scheme for the network
 
     Usage Examples:
 
@@ -127,7 +137,10 @@ def present(name, driver=None, containers=None):
             return ret
         try:
             ret['changes']['created'] = __salt__['docker.create_network'](
-                name, driver=driver)
+                                            name,
+                                            driver=driver,
+                                            options=options,
+                                            ipam=ipam)
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'
                               .format(name, exc))


### PR DESCRIPTION
Porting over changes that were originally made to the state and module by the same name, `dockerng`, to the newer `docker_network` state module and `dockermod` module.   Primarily, we are simply adding additional parameters (`options` and `ipam`) which are passed through all the way down to the docker client.  Additionally, we're updating the function `dockermod.list_tags()` to handle a `repo` parameter to scope down which tags we want listed -- which we use internally to manage/clean_out docker releases.  

I've tested this on a minion where a state which checked for the presence of a docker network was failing, is now passing.   
Before Applying the change
![Screen Shot 2019-04-10 at 3 38 34 PM](https://user-images.githubusercontent.com/7483084/55918110-c045a800-5ba6-11e9-8b98-ee0496e263f7.png)

After the change: 
![Screen Shot 2019-04-10 at 3 01 38 PM](https://user-images.githubusercontent.com/7483084/55918112-c045a800-5ba6-11e9-9990-4af70d136769.png)

**Important note**:  As you can see from the screenshot after the change, it has a warning which is in reference to what we currently have in our salt-formulas state which uses the deprecated `dockerng.network_present` instead of the new `docker_network.present`.  Its able to complete because of in the main router module, `states/_states/docker.py`, it includes `dockerng` as one of the `__virtual_aliases__` which is trying to be helpful and route the call to the updated modules.   This is the primary reason why this state started failing in the first place, as salt was trying to be helpful buy skipping over our custom module by the same name -- `dockerng`.  